### PR TITLE
java support concurrency hacks (for JRuby)

### DIFF
--- a/lib/killbill/gen/plugin-api/currency_plugin_api.rb
+++ b/lib/killbill/gen/plugin-api/currency_plugin_api.rb
@@ -34,6 +34,9 @@ module Killbill
 
         include org.killbill.billing.currency.plugin.api.CurrencyPluginApi
 
+        java_import org.killbill.billing.catalog.api.Currency
+        java_import org.killbill.billing.payment.plugin.api.PaymentPluginApiException
+
         def initialize(real_class_name, services = {})
           super(real_class_name, services)
         end
@@ -47,7 +50,7 @@ module Killbill
           tmp = java.util.TreeSet.new
           (res || []).each do |m|
             # conversion for m [type = org.killbill.billing.catalog.api.Currency]
-            m = Java::org.killbill.billing.catalog.api.Currency.value_of("#{m.to_s}") unless m.nil?
+            m = Currency.value_of(m.to_s) unless m.nil?
             tmp.add(m)
           end
           res = tmp
@@ -58,7 +61,7 @@ module Killbill
             message = "#{message}\n#{e.backtrace.join("\n")}"
           end
           logger.warn message
-          raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_base_currencies failure", e.message)
+          raise PaymentPluginApiException.new("get_base_currencies failure", e.message)
         ensure
           @delegate_plugin.after_request
         end
@@ -74,7 +77,7 @@ module Killbill
           # conversion for res [type = org.joda.time.DateTime]
           if !res.nil?
             res =  (res.kind_of? Time) ? DateTime.parse(res.to_s) : res
-            res = Java::org.joda.time.DateTime.new(res.to_s, Java::org.joda.time.DateTimeZone::UTC)
+            res = org.joda.time.DateTime.new(res.to_s, org.joda.time.DateTimeZone::UTC)
           end
           return res
         rescue Exception => e
@@ -83,7 +86,7 @@ module Killbill
             message = "#{message}\n#{e.backtrace.join("\n")}"
           end
           logger.warn message
-          raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_latest_conversion_date failure", e.message)
+          raise PaymentPluginApiException.new("get_latest_conversion_date failure", e.message)
         ensure
           @delegate_plugin.after_request
         end
@@ -102,7 +105,7 @@ module Killbill
             # conversion for m [type = org.joda.time.DateTime]
             if !m.nil?
               m =  (m.kind_of? Time) ? DateTime.parse(m.to_s) : m
-              m = Java::org.joda.time.DateTime.new(m.to_s, Java::org.joda.time.DateTimeZone::UTC)
+              m = org.joda.time.DateTime.new(m.to_s, org.joda.time.DateTimeZone::UTC)
             end
             tmp.add(m)
           end
@@ -114,7 +117,7 @@ module Killbill
             message = "#{message}\n#{e.backtrace.join("\n")}"
           end
           logger.warn message
-          raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_conversion_dates failure", e.message)
+          raise PaymentPluginApiException.new("get_conversion_dates failure", e.message)
         ensure
           @delegate_plugin.after_request
         end
@@ -142,7 +145,7 @@ module Killbill
             message = "#{message}\n#{e.backtrace.join("\n")}"
           end
           logger.warn message
-          raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_current_rates failure", e.message)
+          raise PaymentPluginApiException.new("get_current_rates failure", e.message)
         ensure
           @delegate_plugin.after_request
         end
@@ -156,7 +159,7 @@ module Killbill
 
         # conversion for conversionDate [type = org.joda.time.DateTime]
         if !conversionDate.nil?
-          fmt = Java::org.joda.time.format.ISODateTimeFormat.date_time_no_millis # See https://github.com/killbill/killbill-java-parser/issues/3
+          fmt = org.joda.time.format.ISODateTimeFormat.date_time_no_millis # See https://github.com/killbill/killbill-java-parser/issues/3
           str = fmt.print(conversionDate)
           conversionDate = DateTime.iso8601(str)
         end
@@ -177,7 +180,7 @@ module Killbill
             message = "#{message}\n#{e.backtrace.join("\n")}"
           end
           logger.warn message
-          raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_rates failure", e.message)
+          raise PaymentPluginApiException.new("get_rates failure", e.message)
         ensure
           @delegate_plugin.after_request
         end

--- a/lib/killbill/gen/plugin-api/currency_plugin_api.rb
+++ b/lib/killbill/gen/plugin-api/currency_plugin_api.rb
@@ -50,7 +50,7 @@ module Killbill
           tmp = java.util.TreeSet.new
           (res || []).each do |m|
             # conversion for m [type = org.killbill.billing.catalog.api.Currency]
-            m = Currency.value_of(m.to_s) unless m.nil?
+            m = Java::JavaLang::Enum.value_of(Currency.java_class, m.to_s) unless m.nil?
             tmp.add(m)
           end
           res = tmp

--- a/lib/killbill/gen/plugin-api/ext_bus_event.rb
+++ b/lib/killbill/gen/plugin-api/ext_bus_event.rb
@@ -34,6 +34,9 @@ module Killbill
 
         include org.killbill.billing.notification.plugin.api.ExtBusEvent
 
+        java_import org.killbill.billing.notification.plugin.api.ExtBusEventType
+        java_import org.killbill.billing.ObjectType
+
         attr_accessor :event_type, :object_type, :object_id, :account_id, :tenant_id
 
         def initialize()
@@ -41,10 +44,10 @@ module Killbill
 
         def to_java()
           # conversion for event_type [type = org.killbill.billing.notification.plugin.api.ExtBusEventType]
-          @event_type = Java::org.killbill.billing.notification.plugin.api.ExtBusEventType.value_of("#{@event_type.to_s}") unless @event_type.nil?
+          @event_type = ExtBusEventType.value_of(@event_type.to_s) unless @event_type.nil?
 
           # conversion for object_type [type = org.killbill.billing.ObjectType]
-          @object_type = Java::org.killbill.billing.ObjectType.value_of("#{@object_type.to_s}") unless @object_type.nil?
+          @object_type = ObjectType.value_of(@object_type.to_s) unless @object_type.nil?
 
           # conversion for object_id [type = java.util.UUID]
           @object_id = java.util.UUID.fromString(@object_id.to_s) unless @object_id.nil?

--- a/lib/killbill/gen/plugin-api/ext_bus_event.rb
+++ b/lib/killbill/gen/plugin-api/ext_bus_event.rb
@@ -44,10 +44,10 @@ module Killbill
 
         def to_java()
           # conversion for event_type [type = org.killbill.billing.notification.plugin.api.ExtBusEventType]
-          @event_type = ExtBusEventType.value_of(@event_type.to_s) unless @event_type.nil?
+          @event_type = Java::JavaLang::Enum.value_of(ExtBusEventType.java_class, @event_type.to_s) unless @event_type.nil?
 
           # conversion for object_type [type = org.killbill.billing.ObjectType]
-          @object_type = ObjectType.value_of(@object_type.to_s) unless @object_type.nil?
+          @object_type = Java::JavaLang::Enum.value_of(ObjectType.java_class, @object_type.to_s) unless @object_type.nil?
 
           # conversion for object_id [type = java.util.UUID]
           @object_id = java.util.UUID.fromString(@object_id.to_s) unless @object_id.nil?

--- a/lib/killbill/gen/plugin-api/notification_plugin_api.rb
+++ b/lib/killbill/gen/plugin-api/notification_plugin_api.rb
@@ -34,6 +34,8 @@ module Killbill
 
         include org.killbill.billing.notification.plugin.api.NotificationPluginApi
 
+        java_import org.killbill.billing.payment.plugin.api.PaymentPluginApiException
+
         def initialize(real_class_name, services = {})
           super(real_class_name, services)
         end
@@ -52,7 +54,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("on_event failure", e.message)
+            raise PaymentPluginApiException.new("on_event failure", e.message)
           ensure
             @delegate_plugin.after_request
           end

--- a/lib/killbill/gen/plugin-api/payment_plugin_api.rb
+++ b/lib/killbill/gen/plugin-api/payment_plugin_api.rb
@@ -34,6 +34,8 @@ module Killbill
 
         include org.killbill.billing.payment.plugin.api.PaymentPluginApi
 
+        java_import org.killbill.billing.payment.plugin.api.PaymentPluginApiException
+
         def initialize(real_class_name, services = {})
           super(real_class_name, services)
         end
@@ -82,7 +84,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("authorize_payment failure", e.message)
+            raise PaymentPluginApiException.new("authorize_payment failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -131,7 +133,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("capture_payment failure", e.message)
+            raise PaymentPluginApiException.new("capture_payment failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -180,7 +182,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("purchase_payment failure", e.message)
+            raise PaymentPluginApiException.new("purchase_payment failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -223,7 +225,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("void_payment failure", e.message)
+            raise PaymentPluginApiException.new("void_payment failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -272,7 +274,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("credit_payment failure", e.message)
+            raise PaymentPluginApiException.new("credit_payment failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -321,7 +323,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("refund_payment failure", e.message)
+            raise PaymentPluginApiException.new("refund_payment failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -364,7 +366,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_payment_info failure", e.message)
+            raise PaymentPluginApiException.new("get_payment_info failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -401,7 +403,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("search_payments failure", e.message)
+            raise PaymentPluginApiException.new("search_payments failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -446,7 +448,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("add_payment_method failure", e.message)
+            raise PaymentPluginApiException.new("add_payment_method failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -480,7 +482,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("delete_payment_method failure", e.message)
+            raise PaymentPluginApiException.new("delete_payment_method failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -517,7 +519,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_payment_method_detail failure", e.message)
+            raise PaymentPluginApiException.new("get_payment_method_detail failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -551,7 +553,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("set_default_payment_method failure", e.message)
+            raise PaymentPluginApiException.new("set_default_payment_method failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -599,7 +601,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("get_payment_methods failure", e.message)
+            raise PaymentPluginApiException.new("get_payment_methods failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -636,7 +638,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("search_payment_methods failure", e.message)
+            raise PaymentPluginApiException.new("search_payment_methods failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -676,7 +678,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("reset_payment_methods failure", e.message)
+            raise PaymentPluginApiException.new("reset_payment_methods failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -719,7 +721,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("build_form_descriptor failure", e.message)
+            raise PaymentPluginApiException.new("build_form_descriptor failure", e.message)
           ensure
             @delegate_plugin.after_request
           end
@@ -752,7 +754,7 @@ module Killbill
               message = "#{message}\n#{e.backtrace.join("\n")}"
             end
             logger.warn message
-            raise Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new("process_notification failure", e.message)
+            raise PaymentPluginApiException.new("process_notification failure", e.message)
           ensure
             @delegate_plugin.after_request
           end

--- a/lib/killbill/gen/plugin-api/payment_plugin_api_exception.rb
+++ b/lib/killbill/gen/plugin-api/payment_plugin_api_exception.rb
@@ -31,6 +31,7 @@ module Killbill
 
       class PaymentPluginApiException
 
+        java_import org.killbill.billing.payment.plugin.api.PaymentPluginApiException
 
         attr_accessor :error_type, :error_message
 
@@ -43,7 +44,7 @@ module Killbill
 
           # conversion for error_message [type = java.lang.String]
           @error_message = @error_message.to_s unless @error_message.nil?
-          Java::org.killbill.billing.payment.plugin.api.PaymentPluginApiException.new(@error_type, @error_message)
+          PaymentPluginApiException.new(@error_type, @error_message)
         end
 
         def to_ruby(j_obj)

--- a/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
+++ b/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
@@ -52,7 +52,7 @@ module Killbill
           @kb_transaction_payment_id = java.util.UUID.fromString(@kb_transaction_payment_id.to_s) unless @kb_transaction_payment_id.nil?
 
           # conversion for transaction_type [type = org.killbill.billing.payment.api.TransactionType]
-          @transaction_type = TransactionType.value_of("#{@transaction_type.to_s}") unless @transaction_type.nil?
+          @transaction_type = TransactionType.value_of(@transaction_type.to_s) unless @transaction_type.nil?
 
           # conversion for amount [type = java.math.BigDecimal]
           if @amount.nil?
@@ -62,7 +62,7 @@ module Killbill
           end
 
           # conversion for currency [type = org.killbill.billing.catalog.api.Currency]
-          @currency = Currency.value_of("#{@currency.to_s}") unless @currency.nil?
+          @currency = Currency.value_of(@currency.to_s) unless @currency.nil?
 
           # conversion for created_date [type = org.joda.time.DateTime]
           if !@created_date.nil?
@@ -77,7 +77,7 @@ module Killbill
           end
 
           # conversion for status [type = org.killbill.billing.payment.plugin.api.PaymentPluginStatus]
-          @status = PaymentPluginStatus.value_of("#{@status.to_s}") unless @status.nil?
+          @status = PaymentPluginStatus.value_of(@status.to_s) unless @status.nil?
 
           # conversion for gateway_error [type = java.lang.String]
           @gateway_error = @gateway_error.to_s unless @gateway_error.nil?

--- a/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
+++ b/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
@@ -30,9 +30,14 @@ module Killbill
     module Model
 
       java_package 'org.killbill.billing.payment.plugin.api'
+
       class PaymentTransactionInfoPlugin
 
         include org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin
+
+        java_import org.killbill.billing.catalog.api.Currency
+        java_import org.killbill.billing.payment.api.TransactionType
+        java_import org.killbill.billing.payment.plugin.api.PaymentPluginStatus
 
         attr_accessor :kb_payment_id, :kb_transaction_payment_id, :transaction_type, :amount, :currency, :created_date, :effective_date, :status, :gateway_error, :gateway_error_code, :first_payment_reference_id, :second_payment_reference_id, :properties
 
@@ -47,7 +52,7 @@ module Killbill
           @kb_transaction_payment_id = java.util.UUID.fromString(@kb_transaction_payment_id.to_s) unless @kb_transaction_payment_id.nil?
 
           # conversion for transaction_type [type = org.killbill.billing.payment.api.TransactionType]
-          @transaction_type = Java::org.killbill.billing.payment.api.TransactionType.value_of("#{@transaction_type.to_s}") unless @transaction_type.nil?
+          @transaction_type = TransactionType.value_of("#{@transaction_type.to_s}") unless @transaction_type.nil?
 
           # conversion for amount [type = java.math.BigDecimal]
           if @amount.nil?
@@ -57,22 +62,22 @@ module Killbill
           end
 
           # conversion for currency [type = org.killbill.billing.catalog.api.Currency]
-          @currency = Java::org.killbill.billing.catalog.api.Currency.value_of("#{@currency.to_s}") unless @currency.nil?
+          @currency = Currency.value_of("#{@currency.to_s}") unless @currency.nil?
 
           # conversion for created_date [type = org.joda.time.DateTime]
           if !@created_date.nil?
             @created_date =  (@created_date.kind_of? Time) ? DateTime.parse(@created_date.to_s) : @created_date
-            @created_date = Java::org.joda.time.DateTime.new(@created_date.to_s, Java::org.joda.time.DateTimeZone::UTC)
+            @created_date = org.joda.time.DateTime.new(@created_date.to_s, Java::org.joda.time.DateTimeZone::UTC)
           end
 
           # conversion for effective_date [type = org.joda.time.DateTime]
           if !@effective_date.nil?
             @effective_date =  (@effective_date.kind_of? Time) ? DateTime.parse(@effective_date.to_s) : @effective_date
-            @effective_date = Java::org.joda.time.DateTime.new(@effective_date.to_s, Java::org.joda.time.DateTimeZone::UTC)
+            @effective_date = org.joda.time.DateTime.new(@effective_date.to_s, Java::org.joda.time.DateTimeZone::UTC)
           end
 
           # conversion for status [type = org.killbill.billing.payment.plugin.api.PaymentPluginStatus]
-          @status = Java::org.killbill.billing.payment.plugin.api.PaymentPluginStatus.value_of("#{@status.to_s}") unless @status.nil?
+          @status = PaymentPluginStatus.value_of("#{@status.to_s}") unless @status.nil?
 
           # conversion for gateway_error [type = java.lang.String]
           @gateway_error = @gateway_error.to_s unless @gateway_error.nil?
@@ -121,7 +126,7 @@ module Killbill
           # conversion for created_date [type = org.joda.time.DateTime]
           @created_date = j_obj.created_date
           if !@created_date.nil?
-            fmt = Java::org.joda.time.format.ISODateTimeFormat.date_time_no_millis # See https://github.com/killbill/killbill-java-parser/issues/3
+            fmt = org.joda.time.format.ISODateTimeFormat.date_time_no_millis # See https://github.com/killbill/killbill-java-parser/issues/3
             str = fmt.print(@created_date)
             @created_date = DateTime.iso8601(str)
           end
@@ -129,7 +134,7 @@ module Killbill
           # conversion for effective_date [type = org.joda.time.DateTime]
           @effective_date = j_obj.effective_date
           if !@effective_date.nil?
-            fmt = Java::org.joda.time.format.ISODateTimeFormat.date_time_no_millis # See https://github.com/killbill/killbill-java-parser/issues/3
+            fmt = org.joda.time.format.ISODateTimeFormat.date_time_no_millis # See https://github.com/killbill/killbill-java-parser/issues/3
             str = fmt.print(@effective_date)
             @effective_date = DateTime.iso8601(str)
           end

--- a/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
+++ b/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
@@ -156,14 +156,11 @@ module Killbill
           @second_payment_reference_id = j_obj.second_payment_reference_id
 
           # conversion for properties [type = java.util.List]
-          @properties = j_obj.properties
-          tmp = []
-          (@properties || []).each do |m|
+          @properties = ( j_obj.properties || [] ).map do |m|
             # conversion for m [type = org.killbill.billing.payment.api.PluginProperty]
             m = Killbill::Plugin::Model::PluginProperty.new.to_ruby(m) unless m.nil?
-            tmp << m
+            m
           end
-          @properties = tmp
           self
         end
 

--- a/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
+++ b/lib/killbill/gen/plugin-api/payment_transaction_info_plugin.rb
@@ -52,7 +52,7 @@ module Killbill
           @kb_transaction_payment_id = java.util.UUID.fromString(@kb_transaction_payment_id.to_s) unless @kb_transaction_payment_id.nil?
 
           # conversion for transaction_type [type = org.killbill.billing.payment.api.TransactionType]
-          @transaction_type = TransactionType.value_of(@transaction_type.to_s) unless @transaction_type.nil?
+          @transaction_type = Java::JavaLang::Enum.value_of(TransactionType.java_class, @transaction_type.to_s) unless @transaction_type.nil?
 
           # conversion for amount [type = java.math.BigDecimal]
           if @amount.nil?
@@ -62,7 +62,7 @@ module Killbill
           end
 
           # conversion for currency [type = org.killbill.billing.catalog.api.Currency]
-          @currency = Currency.value_of(@currency.to_s) unless @currency.nil?
+          @currency = Java::JavaLang::Enum.value_of(Currency.java_class, @currency.to_s) unless @currency.nil?
 
           # conversion for created_date [type = org.joda.time.DateTime]
           if !@created_date.nil?
@@ -77,7 +77,7 @@ module Killbill
           end
 
           # conversion for status [type = org.killbill.billing.payment.plugin.api.PaymentPluginStatus]
-          @status = PaymentPluginStatus.value_of(@status.to_s) unless @status.nil?
+          @status = Java::JavaLang::Enum.value_of(PaymentPluginStatus.java_class, @status.to_s) unless @status.nil?
 
           # conversion for gateway_error [type = java.lang.String]
           @gateway_error = @gateway_error.to_s unless @gateway_error.nil?


### PR DESCRIPTION
... there are actually 2 bugs involved on JRuby's side

1. concurrent constant/method initialization under the `Java` module
    * there's actually separate issue involving package and class initialization (although that is irrelevant here)
    * these usually print warnings under load such as "already initialized constant xxx"

2. the actual `MyEnum.value_of` [bug](https://github.com/killbill/killbill-plugin-framework-ruby/issues/7) which seems more crucial in terms of (execution) consistency

the code showcases possible work-arounds for these until JRuby is fixed. I understand this is all generated code ... and do not expect this to get merged right in but it at least points to where the issues are. this is exactly the part that went into EC2 integration testing.

I only needed - updated the (smaller) plugin-api part. there's also an attempt to get **2** built into the parser: https://github.com/kares/killbill-java-parser/tree/jruby-enum-bug-work-around (likely in-complete - have not used it)

*as a side note, I'd like to note that writing/generating (JRuby) "native" Java (extension) code in the future might be the best approach as a replacement for the current .rb generated code. in terms of JRuby bug immunity, slight performance boost as well as more robust correctness (API errors catched early with compilation).*