### PR TITLE
convert Pathname objects to string before passing to Gem::Installer

### DIFF
--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -220,7 +220,7 @@ module Killbill
     end
 
     def do_install_gem(path, name, version)
-      gem_installer                       = Gem::Installer.new(path,
+      gem_installer                       = Gem::Installer.new(path.to_s,
                                                                {
                                                                    :force       => true,
                                                                    :install_dir => @target_dir,


### PR DESCRIPTION
this makes packaging compatible on RubyGems 2.4.5 (JRuby 1.7.19) ... see #21

incompatibility caused by https://github.com/rubygems/rubygems/blob/master/lib/rubygems/installer.rb#L815

also - compatibility with previous RubyGems (JRuby) versions is fine as well

p.s. commit is be cherry-pickable if you're planning another 3.1.x release