### PR TITLE
(more) rake task improvements

### DIFF
--- a/generators/active_merchant/templates/.gitignore.rb
+++ b/generators/active_merchant/templates/.gitignore.rb
@@ -22,9 +22,6 @@ doc/
 
 .DS_Store
 
-# Build directory
-killbill-<%= identifier %>/
-
 # Testing database
 test.db
 

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -61,6 +61,14 @@ module Killbill
       @plugin_gem_target_dir = @package_dir.join("#{version}/gems").expand_path
     end
 
+    def name
+      @plugin_gemspec.name
+    end
+
+    def version
+      @plugin_gemspec.version
+    end
+
     def specs
       # Rely on the Gemfile definition, if it exists, to get all dependencies
       # (we assume the Gemfile includes the plugin gemspec, as it should).
@@ -156,14 +164,6 @@ module Killbill
     def print_dependencies
       # NOTE: can be improved to include :git info and warn on gem :path
       specs.each { |spec| puts "  #{spec.name} (#{spec.version})" }
-    end
-
-    def name
-      @plugin_gemspec.name
-    end
-
-    def version
-      @plugin_gemspec.version
     end
 
     # Parse the <plugin_name>.gemspec file

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -303,6 +303,9 @@ module Killbill
         gem_target_dir = File.join(target_dir, File.basename(path))
         FileUtils.rm_r(gem_target_dir) if File.exist?(gem_target_dir)
         FileUtils.cp_r(path, target_dir)
+        # the copied .git directory is not needed (might be large) :
+        git_target_dir = File.join(gem_target_dir, '.git')
+        FileUtils.rm_r(git_target_dir) if File.exist?(git_target_dir)
       end
     rescue => e
       @logger.warn "Unable to stage #{spec.name} from #{path}: #{e}"

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -295,9 +295,13 @@ module Killbill
 
       if spec.groups.include?(:killbill_excluded)
         Dir.glob("#{path}/**/#{spec.name}.gemspec").each do |file|
+          gem_target_file = File.join(target_dir, File.basename(file))
+          FileUtils.rm(gem_target_file) if File.exist?(gem_target_file)
           FileUtils.cp(file, target_dir) # gemspec only to avert Bundler error
         end
       else
+        gem_target_dir = File.join(target_dir, File.basename(path))
+        FileUtils.rm_r(gem_target_dir) if File.exist?(gem_target_dir)
         FileUtils.cp_r(path, target_dir)
       end
     rescue => e

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -431,8 +431,8 @@ ENV["RACK_ENV"] = 'production'
 # previously the same WD was used dependent on server startup
 Dir.chdir(File.dirname(__FILE__))
 # prepare to boot using Bundler :
-ENV["BUNDLE_WITHOUT"] ||= "#{ENV["BUNDLE_WITHOUT"] || 'development:test'}"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path('Gemfile', File.dirname(__FILE__))
+ENV["BUNDLE_WITHOUT"] = "#{ENV["BUNDLE_WITHOUT"] || 'development:test'}"
+ENV["BUNDLE_GEMFILE"] = File.expand_path('Gemfile', File.dirname(__FILE__))
 ENV["JBUNDLE_SKIP"] = 'true' # we only use JBundler for development/testing
 
 require 'rubygems' unless defined? Gem

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -388,7 +388,10 @@ ENV["BUNDLE_WITHOUT"] ||= "#{ENV["BUNDLE_WITHOUT"] || 'development:test'}"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path('Gemfile', File.dirname(__FILE__))
 ENV["JBUNDLE_SKIP"] = 'true' # we only use JBundler for development/testing
 
-require 'bundler/setup' if File.exists?(ENV["BUNDLE_GEMFILE"])
+require 'rubygems' unless defined? Gem
+if File.exists?(ENV["BUNDLE_GEMFILE"])
+  require 'bundler'; Bundler.setup
+end
 END
     end
 

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -292,7 +292,10 @@ module Killbill
     end
 
     def validate
-      @gemfile_definition = build_gemfile
+      if @gemfile_definition = build_gemfile
+        @gemfile_definition.resolve
+      end
+      true
     end
 
     def bundler?; !! @gemfile_definition end

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -47,7 +47,7 @@ module Killbill
       @base = Pathname.new(@base_name).expand_path
 
       # Find the gemspec to determine name and version
-      @plugin_gemspec = find_plugin_gemspec
+      @plugin_gemspec = load_plugin_gemspec
 
       # Temporary build directory
       # Don't use 'pkg' as it is used by Rake::PackageTask already: it will
@@ -61,6 +61,8 @@ module Killbill
       # Note the Killbill friendly structure (which we will keep in the tarball)
       @plugin_gem_target_dir = @package_dir.join("#{version}/gems").expand_path
     end
+
+    attr_reader :base
 
     def name
       @plugin_gemspec.name
@@ -164,7 +166,7 @@ module Killbill
     end
 
     def validate
-      @gemfile_definition = find_gemfile
+      @gemfile_definition = build_gemfile
     end
 
     def bundler?; !! @gemfile_definition end
@@ -175,7 +177,7 @@ module Killbill
     end
 
     # Parse the <plugin_name>.gemspec file
-    def find_plugin_gemspec
+    def load_plugin_gemspec
       gemspecs = @plugin_name ? [File.join(@base, "#{@plugin_name}.gemspec")] : Dir[File.join(@base, "{,*}.gemspec")]
       raise "Unable to find your plugin gemspec in #{@base}" if gemspecs.size == 0
       raise "Found multiple plugin gemspec in #{@base} : #{gemspecs.inspect}" if gemspecs.size > 1
@@ -251,7 +253,7 @@ module Killbill
     end
 
     # Parse the existing Gemfile and Gemfile.lock files
-    def find_gemfile
+    def build_gemfile
       gemfile = gemfile_path
       # Don't make the Gemfile a requirement, a gemspec should be enough
       return nil unless gemfile.file?

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -26,6 +26,14 @@ module Killbill
       @verbose = verbose
 
       @logger = Logger.new(STDOUT)
+      @logger.formatter = proc do |severity, datetime, _, msg|
+        date_format = datetime.strftime('%Y-%m-%d %H:%M:%S.%L')
+        if severity == "INFO" || severity == "WARN"
+          "KillBill [#{date_format}] #{severity}  : #{msg}\n"
+        else
+          "KillBill [#{date_format}] #{severity} : #{msg}\n"
+        end
+      end
       @logger.level = @verbose ? Logger::DEBUG : Logger::INFO
 
       @base_name = base_name

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -369,6 +369,8 @@ module Killbill
       gem_installer.spec.extensions       = nil
       gem_installer.spec.extra_rdoc_files = nil
       gem_installer.spec.test_files       = nil
+      # avoid the annoying post_install_message from money gem (and others)
+      gem_installer.spec.post_install_message = nil
 
       gem_installer.install
     rescue => e
@@ -404,15 +406,15 @@ END
 
     def stage_extra_files
       unless boot_rb_file.nil?
-        @logger.debug "Staging (user-suplied) #{boot_rb_file} to #{@plugin_root_target_dir}"
+        @logger.info "Staging (user-suplied) #{boot_rb_file}"
         copy_to_root boot_rb_file
       end
       unless killbill_properties_file.nil?
-        @logger.debug "Staging #{killbill_properties_file} to #{@plugin_root_target_dir}"
+        @logger.debug "Staging #{killbill_properties_file}"
         copy_to_root killbill_properties_file
       end
       unless config_ru_file.nil?
-        @logger.debug "Staging #{config_ru_file} to #{@plugin_root_target_dir}"
+        @logger.debug "Staging #{config_ru_file}"
         copy_to_root config_ru_file
       end
     end

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -254,7 +254,7 @@ module Killbill
       # but it may be better to make sure all dependencies are resolved first,
       # before attempting to build the plugin
       gemfile_lock = gemfile_lock_path
-      raise "Unable to find the Gemfile.lock at #{gemfile_lock} for your plugin. Please run `bundle install' first" unless gemfile_lock.file?
+      raise "Unable to find the bundle .lock at #{gemfile_lock} for your plugin. Please run `bundle install' first" unless gemfile_lock.file?
 
       @logger.debug "Parsing #{gemfile} and #{gemfile_lock}"
       Bundler::Definition.build(gemfile, gemfile_lock, nil)

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -349,7 +349,9 @@ module Killbill
           return spec.source.install_path
         when Bundler::Source::Path
           return false if spec.name == name # it's the plugin gem itself
-          raise "gem #{spec.name}, :path => ... is not supported"
+
+          @logger.warn "gem '#{spec.name}' declares :path => '#{spec.source.path}' packaging will only work locally (while the path exists) !"
+          return spec.source.path
         end
       end
       nil

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -307,14 +307,19 @@ module Killbill
 
     def do_install_gem(path, spec)
       name, version = spec.name, spec.version
-      gem_installer = Gem::Installer.new(path.to_s, {
+      options = {
           :force       => true,
           :install_dir => @target_dir,
           #:only_install_dir => true,
           # Should be redundant with the tweaks below
           :development => false,
           :wrappers    => true
-      })
+      }
+      if Gem::Installer.respond_to?(:at)
+        gem_installer = Gem::Installer.at(path.to_s, options)
+      else # constructing an Installer object with a string is deprecated
+        gem_installer = Gem::Installer.new(path.to_s, options)
+      end
 
       # Tweak the spec file as there are a lot of things we don't care about
       gem_installer.spec.executables      = nil

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -17,7 +17,7 @@ module Killbill
             opts[:gem_name],                      # Gem file name, e.g. 'klogger-1.0.0.gem'
             opts[:gemfile_name] || gemfile_name,  # Gemfile name
             opts[:gemfile_lock_name] || "#{gemfile_name}.lock",
-            opts[:verbose] || false)
+            opts.key?(:verbose) ? opts[:verbose] : ENV['VERBOSE'] == 'true')
         .install
       end
     end

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -269,6 +269,13 @@ module Killbill
             gemspec_name = File.basename(spec.loaded_from)
             plugin_gem = Gem::Package.new(gem_path.to_s)
             puts_to_root plugin_gem.spec.to_ruby, gemspec_name
+            # NOTE: further the unpacked gemspec will be read by Bundler and assumes
+            # the unpacked gem structure to be found on the file-system, extract :
+            # TODO as of now we basically forced the user to pack and we than unpack
+            # the _plugin_ gem - this can be avoided although by doing so we preserved
+            # the previous feature of only packing commited files (due `git ls-files`)
+            # TODO shall we filter out some?
+            plugin_gem.extract_files @plugin_root_target_dir
           end
           @logger.info "Staging #{spec.full_name} from #{gem_path}"
           do_install_gem(gem_path, spec)

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -164,7 +164,8 @@ module Killbill
     # Parse the <plugin_name>.gemspec file
     def find_plugin_gemspec
       gemspecs = @plugin_name ? [File.join(@base, "#{@plugin_name}.gemspec")] : Dir[File.join(@base, "{,*}.gemspec")]
-      raise "Unable to find your plugin gemspec in #{@base}" unless gemspecs.size == 1
+      raise "Unable to find your plugin gemspec in #{@base}" if gemspecs.size == 0
+      raise "Found multiple plugin gemspec in #{@base} : #{gemspecs.inspect}" if gemspecs.size > 1
       spec_path = gemspecs.first
       @logger.debug "Loading #{spec_path}"
       Gem::Specification.load(spec_path)
@@ -309,6 +310,7 @@ module Killbill
       gem_installer = Gem::Installer.new(path.to_s, {
           :force       => true,
           :install_dir => @target_dir,
+          #:only_install_dir => true,
           # Should be redundant with the tweaks below
           :development => false,
           :wrappers    => true

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -164,8 +164,8 @@ module Killbill
       gemspecs = @plugin_name ? [File.join(@base, "#{@plugin_name}.gemspec")] : Dir[File.join(@base, "{,*}.gemspec")]
       raise "Unable to find your plugin gemspec in #{@base}" unless gemspecs.size == 1
       spec_path = gemspecs.first
-      @logger.debug "Parsing #{spec_path}"
-      Bundler.load_gemspec(spec_path)
+      @logger.debug "Loading #{spec_path}"
+      Gem::Specification.load(spec_path)
     end
 
     def find_plugin_gem(spec)

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -13,11 +13,11 @@ module Killbill
     class << self
       def install_tasks(opts = {})
         gemfile_name = ENV['BUNDLE_GEMFILE'] || 'Gemfile'
-        new(opts[:base_name] || Dir.pwd,                        # Path to the plugin root directory (where the gempec and/or Gemfile should be)
-            opts[:plugin_name],                                 # Plugin name, e.g. 'klogger'
-            opts[:gem_name],                                    # Gem file name, e.g. 'klogger-1.0.0.gem'
-            opts[:gemfile_name] || gemfile_name,                # Gemfile name
-            opts[:gemfile_lock_name] || "#{gemfile_name}.lock", # Gemfile.lock name
+        new(opts[:base_name] || Dir.pwd,          # Path to the plugin root directory (where the gempec and/or Gemfile should be)
+            opts[:plugin_name],                   # Plugin name, e.g. 'klogger'
+            opts[:gem_name],                      # Gem file name, e.g. 'klogger-1.0.0.gem'
+            opts[:gemfile_name] || gemfile_name,  # Gemfile name
+            opts[:gemfile_lock_name] || "#{gemfile_name}.lock",
             opts[:verbose] || false)
         .install
       end
@@ -98,8 +98,15 @@ module Killbill
         Rake::Task['package'].add_description "Package #{name} plugin #{version}"
         Rake::Task['repackage'].add_description "Re-package #{name} plugin #{version}"
 
+        task 'stage:init' do
+          # NOOP task for plugins to hook up if they need some sort of initialization
+          #  (task will be run in the context of the Killbill::PluginHelper instance)
+          # NOTE: no need for post (stage:done) hook since it's easy using Rake :
+          #  Rake::Task["killbill:package"].enhance { ... }
+        end
+
         desc "Stage dependencies for #{name} plugin #{version}"
-        task :stage, [:verbose] => :validate do |t, args|
+        task :stage, [:verbose] => [ :validate, 'stage:init' ] do |t, args|
           set_verbosity(args)
 
           stage_dependencies

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -99,8 +99,10 @@ module Killbill
             # should win since those tend to be matched by strict requirements
             if other_spec = all_dependencies.find { |s| s.name == spec.name && s != spec }
               if other_spec.version > spec.version
+                @logger.debug "Discarding matched gem '#{spec.name}' version #{other_spec.version} in favor of #{spec.version}"
                 all_dependencies.delete(other_spec)
               else # other_spec.version < spec.version
+                @logger.debug "Discarding matched gem '#{spec.name}' version #{spec.version} in favor of #{other_spec.version}"
                 all_dependencies.delete(spec)
               end
             end

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -127,9 +127,10 @@ module Killbill
         end
 
         desc "List all dependencies"
-        task :dependency => :validate do
+        task :dependencies => :validate do
           print_dependencies
         end
+        task :dependency => :dependencies
 
         desc "Delete #{@package_dir}"
         task :clean => :clobber_package do
@@ -370,7 +371,6 @@ module Killbill
 
       # Tweak the spec file as there are a lot of things we don't care about
       gem_installer.spec.executables      = nil
-      gem_installer.spec.extensions       = nil
       gem_installer.spec.extra_rdoc_files = nil
       gem_installer.spec.test_files       = nil
       # avoid the annoying post_install_message from money gem (and others)

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -374,6 +374,8 @@ ENV["GEM_HOME"] = File.expand_path('gems', File.dirname(__FILE__))
 ENV["GEM_PATH"] = ENV["GEM_HOME"]
 # environment is set statically, as soon as Sinatra is loaded
 ENV["RACK_ENV"] = 'production'
+# previously the same WD was used dependent on server startup
+Dir.chdir(File.dirname(__FILE__))
 # prepare to boot using Bundler :
 ENV["BUNDLE_WITHOUT"] ||= "#{ENV["BUNDLE_WITHOUT"] || 'development:test'}"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path('Gemfile', File.dirname(__FILE__))

--- a/lib/killbill/rake_task.rb
+++ b/lib/killbill/rake_task.rb
@@ -220,7 +220,11 @@ module Killbill
 
           # NOTE: although same _boot.rb_ as with regular deploys might not work
           stage_extra_files target_dir
-          generate_dev_boot_rb target_dir if boot_rb_file.nil?
+          if boot_rb_file.nil?
+            generate_dev_boot_rb target_dir
+          else
+            @logger.info "Make sure the suplied #{boot_rb_file} is removed/adjusted before doing a regular killbill:deploy (same boot.rb won't likely work)"
+          end
 
           # here we assume Gemfile declares gemspec and we link ROOT to base :
           ln_s @base, target_dir.join(@root_dir_path), :verbose => @verbose


### PR DESCRIPTION
commits should explain, 

should now (at least) pack GEM_HOME into a similar layout as Bundler uses whenever there are gem declarations with :git paths in the Gemfile ... for "normal" gem cases expected to work as previously.

some more details: https://gist.github.com/kares/09520ab72ac8204d229a

---
TODO


* [x] move more boostrap code from JRubyPlugin into boot.rb
* [x] **DRAFT** revisit packaging layout ... up one level (introduce a ROOT directory)
   - [x] due layout changes review generated *boot.rb* works for Bundler-less plugins
* [x] Bunder-less plugin packaging never really packaged gem's dependencies
* [x] confirm the gem `:path` case is in a need for "hacks"
   - [x] make it work with a warning for development purposes
* [x] move the plugin root level staging directory into `pkg` - **moved into `tmp` instead**
   - [x] adjust .gitignore template
* [x] **MINOR** local dev friendly deploy task ... less copying - expanded from git repo + symlink 
     ... possibly using `GEM_HOME` as is?!