### PR TITLE
Fix search_payments method in ActiveMerchant::PaymentPlugin

### DIFF
--- a/lib/killbill/helpers/active_merchant/payment_plugin.rb
+++ b/lib/killbill/helpers/active_merchant/payment_plugin.rb
@@ -146,7 +146,7 @@ module Killbill
 
         def search_payments(search_key, offset = 0, limit = 100, properties, context)
           options = properties_to_hash(properties)
-          @response_model.search(search_key, context.tenant_id, offset, limit, :payment)
+          @response_model.search(search_key, context.tenant_id, offset, limit)
         end
 
         def add_payment_method(kb_account_id, kb_payment_method_id, payment_method_props, set_default, properties, context)

--- a/spec/killbill/helpers/payment_plugin_spec.rb
+++ b/spec/killbill/helpers/payment_plugin_spec.rb
@@ -308,6 +308,17 @@ describe Killbill::Plugin::ActiveMerchant::PaymentPlugin do
       source.first_name.should == 'John'
       source.last_name.should == 'Doe'
     end
+
+    it "should support search_payments" do
+      response = ::Killbill::Test::TestResponse.create(
+        :api_call => :purchase, :kb_payment_id => @kb_payment_id,
+        :kb_account_id => @kb_account_id, :kb_tenant_id => @call_context.tenant_id,
+        :success => true, :created_at => Time.now, :updated_at => Time.now
+      )
+      results = plugin.search_payments(@kb_payment_id, 0, 100, [], @call_context).iterator.to_a
+      results.count.should == 1
+      results.last.kb_payment_id.to_s.should == response.kb_payment_id
+    end
   end
 
   context 'with a dummy gateway' do


### PR DESCRIPTION
Related issue: https://github.com/killbill/killbill-java-parser/pull/9

With my patch in https://github.com/killbill/killbill-java-parser/pull/9, this spec should pass successfully.

```ruby
module Killbill
  module Plugin
    module Model
      class EnumeratorIterator
        alias_method :hasNext, :has_next
      end
    end
  end
end
```

Without the patch, it will raise an error:

``` ruby
 1) Killbill::Plugin::ActiveMerchant::PaymentPlugin when skipping the gateway should support search_payments                                                      [8/46]
     Failure/Error: results = plugin.search_payments(@kb_payment_id, 0, 100, [], @call_context).to_a
     NoMethodError:
       undefined method `hasNext' for #<Killbill::Plugin::Model::EnumeratorIterator:0x3663d0ba>
     # file:/Users/Larry/.rbenv/versions/jruby-1.7.20/lib/jruby.jar!/jruby/java/java_ext/java.lang.rb:12:in `each'
     # ./spec/killbill/helpers/payment_plugin_spec.rb:318:in `(root)'
```

Also, the iterator should just be an iterator, instead of converting it in `to_java` method, which will not work in ruby codes.

