### PR TITLE
set source type to support android pay

### DIFF
--- a/lib/killbill/helpers/active_merchant/payment_plugin.rb
+++ b/lib/killbill/helpers/active_merchant/payment_plugin.rb
@@ -532,7 +532,8 @@ module Killbill
           tokenization_attributes = {
               :eci => Utils.normalized(attributes, :eci),
               :payment_cryptogram => Utils.normalized(attributes, :payment_cryptogram),
-              :transaction_id => Utils.normalized(attributes, :transaction_id)
+              :transaction_id => Utils.normalized(attributes, :transaction_id),
+              :source => Utils.normalized(attributes, :source)
           }
 
           if tokenization_attributes[:eci].nil? &&

--- a/lib/killbill/helpers/active_merchant/payment_plugin.rb
+++ b/lib/killbill/helpers/active_merchant/payment_plugin.rb
@@ -533,7 +533,7 @@ module Killbill
               :eci => Utils.normalized(attributes, :eci),
               :payment_cryptogram => Utils.normalized(attributes, :payment_cryptogram),
               :transaction_id => Utils.normalized(attributes, :transaction_id),
-              :source => Utils.normalized(attributes, :source)
+              :payment_method_type => Utils.normalized(attributes, :payment_method_type)
           }
 
           if tokenization_attributes[:eci].nil? &&


### PR DESCRIPTION
We need to set source so cyberSource plugin can know is it android pay or not. 