### PR TITLE
Merge global configuration into each account specific configuration

### DIFF
--- a/lib/killbill/helpers/active_merchant/configuration.rb
+++ b/lib/killbill/helpers/active_merchant/configuration.rb
@@ -72,7 +72,10 @@ module Killbill
           gateway_configs = config[@@gateway_name.to_sym]
           global_defaults = @@glob_config[@@gateway_name.to_sym] || {}
           # Provided configuration is the same of global (i.e. no tenant specific configuration)
-          global_defaults = {} if gateway_configs == global_defaults
+          unless global_defaults.is_a?(Hash)
+            @@logger.warn "Ignoring #{@@gateway_name} global configuration. Invalid format, expecting a Hash."
+            global_defaults = {}
+          end
 
           gateways_config = {}
           if gateway_configs.is_a?(Array)

--- a/lib/killbill/helpers/active_merchant/configuration.rb
+++ b/lib/killbill/helpers/active_merchant/configuration.rb
@@ -69,11 +69,16 @@ module Killbill
         private
 
         def extract_gateway_config(config)
-          gateways_config = {}
           gateway_configs = config[@@gateway_name.to_sym]
+          global_defaults = @@glob_config[@@gateway_name.to_sym] || {}
+          # Provided configuration is the same of global (i.e. no tenant specific configuration)
+          global_defaults = {} if gateway_configs == global_defaults
+
+          gateways_config = {}
           if gateway_configs.is_a?(Array)
             default_gateway = nil
             gateway_configs.each_with_index do |gateway_config, idx|
+              gateway_config = global_defaults.merge(gateway_config)
               gateway_account_id = gateway_config[:account_id]
               if gateway_account_id.nil?
                 @@logger.warn "Skipping config #{gateway_config} -- missing :account_id"
@@ -88,7 +93,7 @@ module Killbill
             if gateway_configs.nil?
               @@logger.warn "Unable to configure gateway #{@@gateway_name}, invalid configuration: #{config}"
             else
-              gateways_config[:default] = Gateway.wrap(@@gateway_builder, gateway_configs, @@logger)
+              gateways_config[:default] = Gateway.wrap(@@gateway_builder, global_defaults.merge(gateway_configs), @@logger)
             end
           end
           gateways_config

--- a/spec/killbill/helpers/configuration_spec.rb
+++ b/spec/killbill/helpers/configuration_spec.rb
@@ -169,7 +169,7 @@ describe Killbill::Plugin::ActiveMerchant do
   it 'interprets the config file through ERB' do
     value = '<%= 12 %>'
     do_initialize!({ :key => value })
-    ::Killbill::Plugin::ActiveMerchant.config[:test][:key].should == 12
+    ::Killbill::Plugin::ActiveMerchant.config[:test][:key].to_i.should == 12
   end
 
   after do


### PR DESCRIPTION
This PR makes sure we merge the configuration defined in the global plugin config (usually a file deployed with the application), with the config of each of the accounts defined for a plugin.

For the cybersource plugin, .the tenant config hash would look like this:
```ruby
{:cybersource => [{:account_id => 1}, {:account_id => 2}, ...]}
```
While the global config looks like:
```ruby
{:cybersource => {:test => true, :test_url => ...}}
```
That means we can't just merge the two config hashes (which is pointless, since they both contain a `:cybersource` key). We have to, instead, extracts the global config in the `global_defaults` variable, and for each account, merge its configuration with the `global_defaults` hash. Nothing is overwritten.