### PR TITLE
Move the query of max_nb_records into a class method

### DIFF
--- a/lib/killbill/helpers/active_merchant/active_record/models/response.rb
+++ b/lib/killbill/helpers/active_merchant/active_record/models/response.rb
@@ -198,7 +198,7 @@ module Killbill
             pagination                  = ::Killbill::Plugin::Model::Pagination.new
             pagination.current_offset   = offset
             pagination.total_nb_records = self.count_by_sql(self.search_query(search_key, kb_tenant_id))
-            pagination.max_nb_records   = self.where(:success => true).count
+            pagination.max_nb_records   = self.max_nb_records
             pagination.next_offset      = (!pagination.total_nb_records.nil? && offset + limit >= pagination.total_nb_records) ? nil : offset + limit
             # Reduce the limit if the specified value is larger than the number of records
             actual_limit                = [pagination.max_nb_records, limit].min
@@ -216,6 +216,10 @@ module Killbill
           # Override in your plugin if needed
           def self.sensitive_fields
             []
+          end
+
+          def self.max_nb_records
+            self.where(:success => true).count
           end
 
           # Override in your plugin if needed


### PR DESCRIPTION
This is a quick fix of issue #67 , by doing so it could be overridden in any plugins.